### PR TITLE
fix: don't specify nodelist, rely on partition instead

### DIFF
--- a/hydra-genetics/poppy/snakemake_profile_slurm_dev/config.yaml
+++ b/hydra-genetics/poppy/snakemake_profile_slurm_dev/config.yaml
@@ -9,7 +9,7 @@ use-singularity: true
 singularity-prefix: /storage/userdata/singularity_cache
 singularity-args: --bind /storage --bind /scale --bind $HOME --bind /scratch --bind /tmp
 
-cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --nodelist=${{SLURM_JOB_NODELIST:-vs1513,vs1514}} --job-name=poppy.{rule} --output=slurm_logs/{rule}_%j.out
+cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --job-name=poppy.{rule} --output=slurm_logs/{rule}_%j.out
 cluster-status: slurm-status.py
 cluster-cancel: scancel
 

--- a/hydra-genetics/twist-solid/0.13.0/profiles/slurm_hg19_clinical/config.yaml
+++ b/hydra-genetics/twist-solid/0.13.0/profiles/slurm_hg19_clinical/config.yaml
@@ -20,6 +20,6 @@ use-singularity: true
 singularity-prefix: /storage/userdata/snakemake_singularity_cache
 singularity-args: --bind /storage --bind /scale --bind $HOME --bind /scratch --bind /tmp --cleanenv
 
-cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --nodelist=${{SLURM_JOB_NODELIST:-vs1513,vs1514}} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
+cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
 cluster-status: ../../../../../scripts/slurm-status.py
 cluster-cancel: scancel

--- a/hydra-genetics/twist-solid/0.13.0/profiles/slurm_hg19_research/config.yaml
+++ b/hydra-genetics/twist-solid/0.13.0/profiles/slurm_hg19_research/config.yaml
@@ -20,6 +20,6 @@ use-singularity: true
 singularity-prefix: /storage/userdata/snakemake_singularity_cache
 singularity-args: --bind /storage --bind /scale --bind $HOME --bind /scratch --bind /tmp --cleanenv
 
-cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --nodelist=${{SLURM_JOB_NODELIST:-vs1513,vs1514}} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
+cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
 cluster-status: ../../../../../scripts/slurm-status.py
 cluster-cancel: scancel

--- a/hydra-genetics/twist-solid/0.14.0/profiles/slurm_hg19_clinical/config.yaml
+++ b/hydra-genetics/twist-solid/0.14.0/profiles/slurm_hg19_clinical/config.yaml
@@ -20,6 +20,6 @@ use-singularity: true
 singularity-prefix: /storage/userdata/snakemake_singularity_cache
 singularity-args: --bind /storage --bind /scale --bind $HOME --bind /scratch --bind /tmp --cleanenv
 
-cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --nodelist=${{SLURM_JOB_NODELIST:-vs1513,vs1514}} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
+cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
 cluster-status: ../../../../../scripts/slurm-status.py
 cluster-cancel: scancel

--- a/hydra-genetics/twist-solid/0.14.0/profiles/slurm_hg19_research/config.yaml
+++ b/hydra-genetics/twist-solid/0.14.0/profiles/slurm_hg19_research/config.yaml
@@ -20,6 +20,6 @@ use-singularity: true
 singularity-prefix: /storage/userdata/snakemake_singularity_cache
 singularity-args: --bind /storage --bind /scale --bind $HOME --bind /scratch --bind /tmp --cleanenv
 
-cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --nodelist=${{SLURM_JOB_NODELIST:-vs1513,vs1514}} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
+cluster: sbatch --parsable --time={resources.time} --cpus-per-task={resources.threads} --mem-per-cpu={resources.mem_per_cpu} --partition={resources.partition} --job-name=twist-solid.{rule} --output=slurm_logs/{rule}_%j.out
 cluster-status: ../../../../../scripts/slurm-status.py
 cluster-cancel: scancel


### PR DESCRIPTION
Specifying `--nodelist` makes the job allocate these nodes for the job in question, even though they could manage with way less resources. Removing this and instead relying on that the partition has the relevant nodes listed will be a better solution.