### PR TITLE
feat: update nf-core/raredisease to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Inspired by [Clinical-Genomics/reference-files](https://github.com/Clinical-Geno
 
 ## nf-core/raredisease
 
-To run the raredisease pipeline in a clinical setting on our cluster, run the following commands:
+To run the raredisease pipeline in a clinical setting on our cluster, run the following command:
 
 ```bash
-nextflow run nf-core/raredisease \
+nextflow \
+    run \
     -c $NEXTFLOW_CONFIG_HOME/nf-core/raredisease/raredisease.config \
-    --params-file $NEXTFLOW_CONFIG_HOME/nf-core/raredisease/params.yaml \
-    -profile rv,clinical \
-    --analysis_type wgs
+    -c $NEXTFLOW_CONFIG_HOME/nf-core/rv.config \
+    -params-file $NEXTFLOW_CONFIG_HOME/nf-core/raredisease/params.yaml \
+    -profile clinical \
+    nf-core/raredisease
 ```
 
 `$NEXTFLOW_CONFIG_HOME` is the path to the `nextflow` directory in a clone of this repo. The `rv` (Region Västerbotten) profile is the general cluster config for nf-core and should be used for all nf-core pipelines. For this config there are also two additional profiles: `clinical` and `research`. These are also general, and will decide what priority the jobs will get on the cluster.
@@ -40,3 +42,11 @@ It is also possible to use plumber to validate the plumberfile.
 Due to plumber rearranging the config files to some extent, it needs to be able to control file paths in any config files that refer to files within this repo.
 This can be seen in action in the [config for nf-core/raredisease](./nextflow/nf-core/raredisease/raredisease.config).
 Since this approach has yet to be extensively tested, it might be subject to change.
+
+To run the same example that is presented at the beginning of this document, run the command:
+
+```bash
+plumber nextflow run -p clinical nf-core/raredisease
+```
+
+Configs and assets will be downloaded automatically, and the appropriate environment variables will be set.

--- a/nextflow/nf-core/raredisease/params.yaml
+++ b/nextflow/nf-core/raredisease/params.yaml
@@ -16,7 +16,7 @@ variant_caller: deepvariant
 
 # Annotation
 vep_cache: /storage/userdata/references/vep
-vep_cache_version: 110
+vep_cache_version: 113
 gnomad_af: /storage/userdata/references/homo_sapiens/GRCh38_hg38/gnomad/gnomad.genomes.v4.1.sites.af.tab.gz
 
 # Skip some things for now since we don't have normal panels or other
@@ -26,6 +26,3 @@ skip_sv_annotation: true
 skip_me_calling: true
 skip_me_annotation: true
 skip_mt_annotation: true
-
-# VEP filtering is broken, so skip it for now until VEP 113 has been released
-skip_vep_filter: true

--- a/nextflow/nf-core/raredisease/raredisease.config
+++ b/nextflow/nf-core/raredisease/raredisease.config
@@ -11,7 +11,10 @@ if (assets_dir == null) {
 }
 
 params {
+    fasta = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
+    fai = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa.fai"
     bwamem2 = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/bwamem2Index"
+    mito_name = "chrM"
     intervals_wgs = "${assets_dir}/GRCh38_chr1-chr22chrXchrYchrM.interval_list"
     intervals_y = "${assets_dir}/GRCh38_chrY.interval_list"
     variant_catalog = "${assets_dir}/raredisease/disease_loci/ExpansionHunter-v5.0.0/variant_catalog_grch38.json"

--- a/nextflow/nf-core/raredisease/raredisease.config
+++ b/nextflow/nf-core/raredisease/raredisease.config
@@ -29,9 +29,6 @@ params {
     vep_plugin_files = "${assets_dir}/raredisease/vep_plugin_files.csv"
 }
 
-// VEP filtering is broken, so skip it for now until VEP 113 has been released
-skip_vep_filter = true
-
 process {
     withName: 'NFCORE_RAREDISEASE:RAREDISEASE:ANNOTATE_GENOME_SNVS:VCFANNO' {
         cpus = 12

--- a/nextflow/nf-core/rv.config
+++ b/nextflow/nf-core/rv.config
@@ -1,35 +1,35 @@
 // vim: ft=groovy syntax=nextflow
 
+params {
+    config_profile_contact = "Niklas Mähler (maehler)"
+    config_profile_url = "https://github.com/gmc-norr"
+}
+
+process {
+    executor = "slurm"
+    queue = "clinical"
+    scratch = "/tmp"
+    maxRetries = 2
+    resourceLimits = [
+        time: "24.h",
+        cpus: 256,
+        memory: "2063602.MB"
+    ]
+}
+
+executor {
+    queueSize = 100
+    submitRateLimit = "10 sec"
+}
+
+apptainer {
+    enabled = true
+    autoMounts = true
+    cacheDir = "/storage/userdata/nextflow_apptainer_cache"
+    runOptions = "--cleanenv"
+}
+
 profiles {
-    rv {
-        params {
-            config_profile_contact = "Niklas Mähler (maehler)"
-            config_profile_url = "https://github.com/gmc-norr"
-            max_time = 24.h
-            max_cpus = 256
-            max_memory = 2063602.MB
-        }
-
-        process {
-            executor = "slurm"
-            queue = "clinical"
-            scratch = "/tmp"
-            maxRetries = 2
-        }
-
-        executor {
-            queueSize = 100
-            submitRateLimit = "10 sec"
-        }
-
-        apptainer {
-            enabled = true
-            autoMounts = true
-            cacheDir = "/storage/userdata/nextflow_apptainer_cache"
-            runOptions = "--cleanenv"
-        }
-    }
-
     clinical {
         params.config_profile_description = "GMC Norr nf-core profile for clinical use"
         process.queue = "clinical"

--- a/plumber.yaml
+++ b/plumber.yaml
@@ -2,7 +2,7 @@ version: 1
 pipelines:
   - name: nf-core/raredisease
     engine: nextflow
-    version: "2.2.0"
+    version: "2.3.0"
     profiles:
       - ./nextflow/nf-core/rv.config
     config_files:


### PR DESCRIPTION
This PR updates the config for nf-core/raredisease to support v2.3.0. In doing this, the VEP version was also updated to 113, which should mean that the VEP filters that were previously broken should be functional. The update to the pipeline seems to have changed how igenomes reference files are handled, and therefore I resorted to putting the reference files into the pipeline config.

Another thing that was addressed was the profile config which now defaults to the profile that was previously called `rv`, so it is enough to include this config file for this to be active. The profiles `clinical` and `research` work just like before.