### PR TITLE
feat: update nf-core/raredisease to 2.4.0

### DIFF
--- a/nextflow/nf-core/raredisease/raredisease.config
+++ b/nextflow/nf-core/raredisease/raredisease.config
@@ -84,6 +84,7 @@ process {
     }
 
     withName: 'NFCORE_RAREDISEASE:RAREDISEASE:QC_BAM:MOSDEPTH' {
+        container = 'https://depot.galaxyproject.org/singularity/mosdepth:0.3.10--h4e814b3_1'
         ext.args = '--d4'
     }
 }

--- a/nextflow/nf-core/raredisease/raredisease.config
+++ b/nextflow/nf-core/raredisease/raredisease.config
@@ -82,4 +82,8 @@ process {
     withName: 'NFCORE_RAREDISEASE:RAREDISEASE:CALL_STRUCTURAL_VARIANTS:CALL_SV_TIDDIT:SVDB_MERGE_TIDDIT' {
         ext.prefix = { "${meta.id}_tiddit.svdb_merge" }
     }
+
+    withName: 'NFCORE_RAREDISEASE:RAREDISEASE:QC_BAM:MOSDEPTH' {
+        ext.args = '--d4'
+    }
 }

--- a/plumber.yaml
+++ b/plumber.yaml
@@ -2,7 +2,7 @@ version: 1
 pipelines:
   - name: nf-core/raredisease
     engine: nextflow
-    version: "2.3.0"
+    version: "2.4.0"
     profiles:
       - ./nextflow/nf-core/rv.config
     config_files:


### PR DESCRIPTION
This bumps the raredisease pipeline to 2.4.0, and in this I also had to update the mosdepth container due to a bug where the `--d4` flag was missing in 0.3.8 for unknown reasons. In version 2.3.0 of the pipeline, the d4 files were removed from the default output, so this has been added back.