### PR TITLE
fix(nf-core/raredisese): skip SV calling

### DIFF
--- a/nextflow/nf-core/raredisease/params.yaml
+++ b/nextflow/nf-core/raredisease/params.yaml
@@ -21,6 +21,7 @@ gnomad_af: /storage/userdata/references/homo_sapiens/GRCh38_hg38/gnomad/gnomad.g
 
 # Skip some things for now since we don't have normal panels or other
 # info needed for these steps.
+skip_sv_calling: true
 skip_germlinecnvcaller: true
 skip_sv_annotation: true
 skip_me_calling: true


### PR DESCRIPTION
Version 0.4 of the config files have only been validated for SNV and INDEL calling, and still some structural variants are being called. By omitting the SV calling we save both time and disk space for the cases where we won't be using these results anyways.