### PR TITLE
fix(twist-solid): bump resources

### DIFF
--- a/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
+++ b/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
@@ -69,8 +69,8 @@ manta_run_workflow_t:
 
 optitype:
   time: "8:00:00"
-  threads: 26
-  mem_mb: 104000
+  threads: 32
+  mem_mb: 128000
 
 star:
   time: "8:00:00"

--- a/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
+++ b/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
@@ -36,8 +36,8 @@ fgbio_group_reads_by_umi:
 
 fuseq_wes:
   time: "48:00:00"
-  threads: 4
-  mem_mb: 16000
+  threads: 8
+  mem_mb: 32000
 
 fusioncatcher:
   threads: 10


### PR DESCRIPTION
This bumps the resources for fuseq_wes and optitype to avoid OOM kills. This is something we seem to see relatively frequently with data from NovaSeq X Plus, simply due to the amount of data.