### PR TITLE
fix: bump resources for optitype

### DIFF
--- a/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
+++ b/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
@@ -73,9 +73,9 @@ manta_run_workflow_t:
   mem_mb: 16000
 
 optitype:
-  time: "8:00:00"
-  threads: 32
-  mem_mb: 128000
+  time: "16:00:00"
+  threads: 64
+  mem_mb: 256000
 
 star:
   time: "8:00:00"

--- a/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
+++ b/hydra-genetics/twist-solid/0.23.0/configs/resources.yaml
@@ -61,8 +61,8 @@ gene_fuse:
 
 juli_call:
   time: "48:00:00"
-  threads: 24
-  mem_mb: 96000
+  threads: 32
+  mem_mb: 128000
 
 jumble_run:
   threads: 10


### PR DESCRIPTION
Bump resources, again, for optitype. still get OOM for some jobs.